### PR TITLE
Verify.exe broken on Windows

### DIFF
--- a/verify/verify/cli_local_verify.go
+++ b/verify/verify/cli_local_verify.go
@@ -111,7 +111,7 @@ func loadFilesAndMakeRequest(baseUrl, schemaPath, examplePath string, verbose bo
 }
 
 func examplesForSchema(schemaPath string, cliExec CLIExecution) (verifications []SchemaExample, err error) {
-  dirname,filename := p.Split(schemaPath)
+  dirname,filename := fp.Split(schemaPath)
   exampleFilename := strings.Replace(filename, ".json", "", -1)
   exampleFilenameGlob := fmt.Sprintf("%s_ex_*.json", exampleFilename)
 


### PR DESCRIPTION
The schema path split needs to be os.PathSeparator aware or no examples will be found for each schema on Windows
